### PR TITLE
Fix regex to find tcp correctly

### DIFF
--- a/Nmap/Script
+++ b/Nmap/Script
@@ -5,7 +5,7 @@ if (lineInputCount < 5)
 	return new ScriptOutput();
 }
 
-var match = System.Text.RegularExpressions.Regex.Match(lineInput, @"(.*?)/tcp\s*open\s*(.*?)$");
+var match = System.Text.RegularExpressions.Regex.Match(lineInput, @"(.*?)\/tcp\s*open\s*(.*?)$");
 if (match.Success && match.Groups.Count == 3)
 {
     var scriptOutput = new ScriptOutput { Service = match.Groups[2].Value, Port = int.Parse(match.Groups[1].Value) };


### PR DESCRIPTION
Current Regex pattern will not work properly, you forget to escape slash(/) character.