### PR TITLE
OneForAll agent

### DIFF
--- a/OneForAll/OneForAllWrapper.go
+++ b/OneForAll/OneForAllWrapper.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"bufio"
 	"flag"
 	"io/ioutil"
@@ -38,7 +39,7 @@ func ReadFile(filePath string) []string {
 
 //OneForAll executes the OneForAll python script
 func OneForAll(domain string, outputDir string) {
-	cmd := exec.Command("python3", "/app/OneForAll/oneforall.py", "--target", domain, "--path", outputDir, "run")
+	cmd := exec.Command("python3", "OneForAll/oneforall.py", "--target", domain, "--path", outputDir, "run")
 
 	if err := cmd.Start(); err != nil {
 		log.Fatal(err)
@@ -64,7 +65,8 @@ func ParseData(outputDir string) {
 		if strings.Contains(file.Name(), ".txt") {
 			content := ReadFile(cwd + "/" + outputDir + "/" + file.Name())
 			for _, line := range content {
-				println(line)
+				fmt.Println(line)
+				time.Sleep(1 * time.Second)
 			}
 		}
 	}

--- a/OneForAll/OneForAllWrapper.go
+++ b/OneForAll/OneForAllWrapper.go
@@ -5,9 +5,11 @@ import (
 	"flag"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 //ReadFile reads the content of a file and returns an array of it's content
@@ -35,8 +37,8 @@ func ReadFile(filePath string) []string {
 }
 
 //OneForAll executes the OneForAll python script
-func OneForAll(domain string) {
-	cmd := exec.Command("python3", "/app/OneForAll/oneforall.py", "--target", domain, "--path", "tmp", "run")
+func OneForAll(domain string, outputDir string) {
+	cmd := exec.Command("python3", "/app/OneForAll/oneforall.py", "--target", domain, "--path", outputDir, "run")
 
 	if err := cmd.Start(); err != nil {
 		log.Fatal(err)
@@ -47,33 +49,50 @@ func OneForAll(domain string) {
 }
 
 //ParseData reads the output of the OneForAll script and prints it to stdout
-func ParseData() {
+func ParseData(outputDir string) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	files, err := ioutil.ReadDir("tmp/")
+	files, err := ioutil.ReadDir(outputDir + "/")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	for _, file := range files {
 		if strings.Contains(file.Name(), ".txt") {
-			content := ReadFile(cwd + "/tmp/" + file.Name())
+			content := ReadFile(cwd + "/" + outputDir + "/" + file.Name())
 			for _, line := range content {
 				println(line)
 			}
 		}
 	}
-	os.RemoveAll("tmp/")
+	os.RemoveAll(outputDir + "/")
+}
+
+func GenerateRandomString() string {
+	rand.Seed(time.Now().UnixNano())
+	chars := []rune(
+		"abcdefghijklmnopqrstuvwxyz" +
+			"0123456789")
+	length := 8
+	var b strings.Builder
+	for i := 0; i < length; i++ {
+		b.WriteRune(chars[rand.Intn(len(chars))])
+	}
+	str := b.String() // E.g. "ExcbsVQs"
+
+	return str
 }
 
 func main() {
 	domain := flag.String("d", "", "Domain")
 	flag.Parse()
 
-	OneForAll(*domain)
-	ParseData()
+	outputDir := GenerateRandomString()
+
+	OneForAll(*domain, outputDir)
+	ParseData(outputDir)
 
 }

--- a/OneForAll/OneForAllWrapper.go
+++ b/OneForAll/OneForAllWrapper.go
@@ -74,6 +74,8 @@ func CopyOneForAll(dir string) {
 
 func main() {
 	domain := flag.String("d", "", "Domain")
+	flag.Parse()
+
 	OneForAll(*domain)
 	CopyOneForAll("/root/app/OneForAll/")
 

--- a/OneForAll/OneForAllWrapper.go
+++ b/OneForAll/OneForAllWrapper.go
@@ -38,7 +38,7 @@ func ReadFile(filePath string) []string {
 func OneForAll(domain string) {
 	println("starting one for all")
 
-	cmd := exec.Command("python3", "/root/app/OneForAll/oneforall.py", "--target", domain, "--path", "tmp", "run")
+	cmd := exec.Command("python3", "/app/OneForAll/oneforall.py", "--target", domain, "--path", "tmp", "run")
 
 	println(cmd.String())
 	stderr, _ := cmd.StderrPipe()
@@ -77,6 +77,6 @@ func main() {
 	flag.Parse()
 
 	OneForAll(*domain)
-	CopyOneForAll("/root/app/OneForAll/")
+	CopyOneForAll("/app/OneForAll/")
 
 }

--- a/OneForAll/OneForAllWrapper.go
+++ b/OneForAll/OneForAllWrapper.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func ReadFile(filePath string) []string {
+	file, err := os.Open(filePath)
+	var content []string
+
+	if err != nil {
+		log.Fatal(err)
+		return nil
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		//fmt.Println(scanner.Text())
+		content = append(content, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+		return nil
+	}
+
+	return content
+}
+
+func OneForAll(domain string) {
+	println("starting one for all")
+
+	cmd := exec.Command("python3", "/root/app/OneForAll/oneforall.py", "--target", domain, "--path", "tmp", "run")
+
+	println(cmd.String())
+	stderr, _ := cmd.StderrPipe()
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	scanner := bufio.NewScanner(stderr)
+	for scanner.Scan() {
+		fmt.Println(scanner.Text())
+	}
+	cmd.Wait()
+
+}
+
+func CopyOneForAll(dir string) {
+
+	files, err := ioutil.ReadDir(dir + "tmp/")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, file := range files {
+		if strings.Contains(file.Name(), ".txt") {
+			content := ReadFile(dir + "tmp/" + file.Name())
+			for _, line := range content {
+				println(line)
+			}
+		}
+		os.RemoveAll(dir + "tmp/")
+	}
+}
+
+func main() {
+	domain := flag.String("d", "", "Domain")
+	OneForAll(*domain)
+	CopyOneForAll("/root/app/OneForAll/")
+
+}

--- a/OneForAll/OneForAllWrapper.go
+++ b/OneForAll/OneForAllWrapper.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"strings"
 )
 
+//ReadFile reads the content of a file and returns an array of it's content
 func ReadFile(filePath string) []string {
 	file, err := os.Open(filePath)
 	var content []string
@@ -23,7 +23,6 @@ func ReadFile(filePath string) []string {
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		//fmt.Println(scanner.Text())
 		content = append(content, scanner.Text())
 	}
 
@@ -35,41 +34,39 @@ func ReadFile(filePath string) []string {
 	return content
 }
 
+//OneForAll executes the OneForAll python script
 func OneForAll(domain string) {
-	println("starting one for all")
-
 	cmd := exec.Command("python3", "/app/OneForAll/oneforall.py", "--target", domain, "--path", "tmp", "run")
 
-	println(cmd.String())
-	stderr, _ := cmd.StderrPipe()
 	if err := cmd.Start(); err != nil {
 		log.Fatal(err)
 	}
 
-	scanner := bufio.NewScanner(stderr)
-	for scanner.Scan() {
-		fmt.Println(scanner.Text())
-	}
 	cmd.Wait()
 
 }
 
-func CopyOneForAll(dir string) {
+//ParseData reads the output of the OneForAll script and prints it to stdout
+func ParseData() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	files, err := ioutil.ReadDir(dir + "tmp/")
+	files, err := ioutil.ReadDir("tmp/")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	for _, file := range files {
 		if strings.Contains(file.Name(), ".txt") {
-			content := ReadFile(dir + "tmp/" + file.Name())
+			content := ReadFile(cwd + "/tmp/" + file.Name())
 			for _, line := range content {
 				println(line)
 			}
 		}
-		os.RemoveAll(dir + "tmp/")
 	}
+	os.RemoveAll("tmp/")
 }
 
 func main() {
@@ -77,6 +74,6 @@ func main() {
 	flag.Parse()
 
 	OneForAll(*domain)
-	CopyOneForAll("/app/OneForAll/")
+	ParseData()
 
 }

--- a/OneForAll/Script
+++ b/OneForAll/Script
@@ -1,0 +1,9 @@
+using ReconNess.Core.Models;
+
+var match = System.Text.RegularExpressions.Regex.Match(lineInput, @"([^\.\/]+)(\.[^\.\/]+)+(?:\/|$)");
+if (match.Success)
+{
+    return new ScriptOutput { Subdomain = match.Groups[0].Value };
+}
+
+return new ScriptOutput();

--- a/OneForAll/readme.md
+++ b/OneForAll/readme.md
@@ -1,11 +1,13 @@
 ## OneForAll Command
 
-Using {{rootDomain}} ReconNess replace {{rootDomain}} for the subdomain.
+Using {{rootDomain}} ReconNess replace {{rootDomain}} for the root domain. Ex: yahoo.com
 
+If we have OneForAllWrapper in the folder ~/Desktop/OneForAllWrapper/
 
 ```
-/usr/local/go/bin/go run OneForAllWrapper.go -d {{rootDomain}} 
+cd ~/Desktop/OneForAllWrapper && /usr/local/go/bin/go run OneForAllWrapper.go -d {{rootDomain}} 
 ```
+
 ## OneForAll Command for Docker
 
 ```

--- a/OneForAll/readme.md
+++ b/OneForAll/readme.md
@@ -1,0 +1,9 @@
+OneForAll Dockerfile Entry
+
+RUN git clone https://github.com/shmilylty/OneForAll.git
+RUN cd OneForAll/
+RUN python -m pip install -U pip setuptools wheel
+RUN pip3 install -r requirements.txt
+RUN python3 oneforall.py --help
+
+

--- a/OneForAll/readme.md
+++ b/OneForAll/readme.md
@@ -6,4 +6,39 @@ RUN python -m pip install -U pip setuptools wheel
 RUN pip3 install -r requirements.txt
 RUN python3 oneforall.py --help
 
+## OneForAll Command
+
+Using {{domain}} ReconNess replace {{domain}} for the subdomain.
+
+
+```
+./OneForAllWrapper.go -d {{domain}} 
+```
+## OneForAll Command for Docker
+
+```
+cd /app/OneForAllWrapper && go run OneForAllWrapper.go -d {{domain}} 
+```
+
+## OneForAll Script
+
+Check [Script file](add script file location)
+
+## OneForAll Dockerfile Entry
+
+```
+# -------- Agents dependencies -------- 
+
+# To allow run gobuster inside the docker
+
+RUN apt-get update && apt-get install -y git
+RUN apt-get install -y wget
+RUN wget https://dl.google.com/go/go1.13.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.13.linux-amd64.tar.gz
+RUN echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.profile
+RUN mkdir OneForAllWrapper && cd OneForAllWrapper && wget https://raw.githubusercontent.com/hiddengearz/reconness-agents/master/OneForAll/OneForAllWrapper.go
+
+# -------- End Agents dependencies -------- 
+```
+
 

--- a/OneForAll/readme.md
+++ b/OneForAll/readme.md
@@ -1,23 +1,15 @@
-OneForAll Dockerfile Entry
-
-RUN git clone https://github.com/shmilylty/OneForAll.git
-RUN cd OneForAll/
-RUN python -m pip install -U pip setuptools wheel
-RUN pip3 install -r requirements.txt
-RUN python3 oneforall.py --help
-
 ## OneForAll Command
 
 Using {{domain}} ReconNess replace {{domain}} for the subdomain.
 
 
 ```
-./OneForAllWrapper.go -d {{domain}} 
+/usr/local/go/bin/go run OneForAllWrapper.go -d {{domain}} 
 ```
 ## OneForAll Command for Docker
 
 ```
-cd /app/OneForAllWrapper && go run OneForAllWrapper.go -d {{domain}} 
+cd /app/OneForAllWrapper && /usr/local/go/bin/go run OneForAllWrapper.go -d {{domain}} 
 ```
 
 ## OneForAll Script
@@ -31,12 +23,18 @@ Check [Script file](add script file location)
 
 # To allow run gobuster inside the docker
 
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git python3 python3-pip
 RUN apt-get install -y wget
-RUN wget https://dl.google.com/go/go1.13.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.13.linux-amd64.tar.gz
-RUN echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.profile
+RUN wget https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.13.4.linux-amd64.tar.gz
+RUN echo 'export GOROOT=/usr/local/go' >> ~/.profile
+RUN echo 'export GOPATH=$HOME/go'	>> ~/.profile
+RUN echo 'export PATH=$GOPATH/bin:$GOROOT/bin:$PATH' >> ~/.profile
+RUN . ~/.profile
 RUN mkdir OneForAllWrapper && cd OneForAllWrapper && wget https://raw.githubusercontent.com/hiddengearz/reconness-agents/master/OneForAll/OneForAllWrapper.go
+RUN git clone https://github.com/shmilylty/OneForAll.git
+RUN python3 -m pip install -U pip setuptools wheel
+RUN pip3 install -r /app/OneForAll/requirements.txt
 
 # -------- End Agents dependencies -------- 
 ```

--- a/OneForAll/readme.md
+++ b/OneForAll/readme.md
@@ -11,7 +11,7 @@ cd ~/Desktop/OneForAllWrapper && /usr/local/go/bin/go run OneForAllWrapper.go -d
 ## OneForAll Command for Docker
 
 ```
-cd /app/OneForAllWrapper && /usr/local/go/bin/go run OneForAllWrapper.go -d {{rootDomain}} 
+/usr/local/go/bin/go run OneForAllWrapper.go -d {{rootDomain}} 
 ```
 
 ## OneForAll Script
@@ -33,7 +33,7 @@ RUN echo 'export GOROOT=/usr/local/go' >> ~/.profile
 RUN echo 'export GOPATH=$HOME/go'	>> ~/.profile
 RUN echo 'export PATH=$GOPATH/bin:$GOROOT/bin:$PATH' >> ~/.profile
 RUN . ~/.profile
-RUN mkdir OneForAllWrapper && cd OneForAllWrapper && wget https://raw.githubusercontent.com/hiddengearz/reconness-agents/master/OneForAll/OneForAllWrapper.go
+RUN wget https://raw.githubusercontent.com/hiddengearz/reconness-agents/master/OneForAll/OneForAllWrapper.go
 RUN git clone https://github.com/shmilylty/OneForAll.git
 RUN python3 -m pip install -U pip setuptools wheel
 RUN pip3 install -r /app/OneForAll/requirements.txt

--- a/OneForAll/readme.md
+++ b/OneForAll/readme.md
@@ -1,15 +1,15 @@
 ## OneForAll Command
 
-Using {{domain}} ReconNess replace {{domain}} for the subdomain.
+Using {{rootDomain}} ReconNess replace {{rootDomain}} for the subdomain.
 
 
 ```
-/usr/local/go/bin/go run OneForAllWrapper.go -d {{domain}} 
+/usr/local/go/bin/go run OneForAllWrapper.go -d {{rootDomain}} 
 ```
 ## OneForAll Command for Docker
 
 ```
-cd /app/OneForAllWrapper && /usr/local/go/bin/go run OneForAllWrapper.go -d {{domain}} 
+cd /app/OneForAllWrapper && /usr/local/go/bin/go run OneForAllWrapper.go -d {{rootDomain}} 
 ```
 
 ## OneForAll Script


### PR DESCRIPTION
I've created a wrapper for OneForAll that prints the subdomains it finds. OneForAll is a subdomain enumeration tool, it's similar to amass but uses many Chinese sources that amass doesn't have. Unfortunately I wasn't able to test the C# script but it looks to just be a regex for domains and this wrapper only prints the domains

Please don't forget to change `https://raw.githubusercontent.com/hiddengearz/reconness-agents/master/OneForAll/OneForAllWrapper.go` to `https://raw.githubusercontent.com/reconness/reconness-agents/master/OneForAll/OneForAllWrapper.go` in the readme