### PR TITLE
Fix amass install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN . ~/.profile && go get -u github.com/projectdiscovery/subfinder/cmd/subfinde
 
 # To allow run amass inside the docker
 RUN cd /tmp/ ; wget https://github.com/OWASP/Amass/releases/download/v3.7.4/amass_linux_amd64.zip ; unzip amass_linux_amd64.zip
-RUN mv /tmp/amass_linux_amd64.zip/amass /bin
+RUN mv /tmp/amass_linux_amd64/amass /bin
 
 # To allow run gobuster inside the docker
 RUN . ~/.profile && go get github.com/OJ/gobuster


### PR DESCRIPTION
When you unzip the folder is called /amass_linux_amd64 not /amass_linux_amd64.zip